### PR TITLE
add SQS_QUEUE_NAMES option to watch specific queues

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ AWS credentials can be provided via the following:
 * Instance profile credentials delivered through the Amazon EC2 metadata service if running within AWS
 * IAM role applied to either an Amazon Elastic Container Service (ECS) service or task
 
-By default, the exporter will watch all SQS queues visible to the AWS account. To watch a speciifc set of queues, supply a comma-separated list of queue names in the environment variable SQS_QUEUE_NAMES.
+By default, the exporter will watch all SQS queues visible to the AWS account. To watch a specific set of queues, supply a comma-separated list of queue names in the environment variable SQS_QUEUE_NAMES.
 
 ## Docker
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ AWS credentials can be provided via the following:
 * Instance profile credentials delivered through the Amazon EC2 metadata service if running within AWS
 * IAM role applied to either an Amazon Elastic Container Service (ECS) service or task
 
+By default, the exporter will watch all SQS queues visible to the AWS account. To watch a speciifc set of queues, supply a comma-separated list of queue names in the environment variable SQS_QUEUE_NAMES.
 
 ## Docker
 

--- a/src/main/java/org/jmal98/metrics/collector/Sqs.java
+++ b/src/main/java/org/jmal98/metrics/collector/Sqs.java
@@ -44,8 +44,24 @@ public class Sqs extends Collector {
 				logger.info("AmazonSQS client is connected to region: ({})", region);
 			}
 
-			ListQueuesResult queues = sqs.listQueues();
-			for (String qUrl : queues.getQueueUrls()) {
+			List<String> queueUrls;
+
+			// check for manually-specified queue names
+			String queueNames = System.getenv("SQS_QUEUE_NAMES");
+			if (queueNames != null) {
+			    // find the URLs for the named queues
+			    String[] names = queueNames.split(",");
+			    queueUrls = new ArrayList<String>();
+			    for(String name : names) {
+				queueUrls.add(sqs.getQueueUrl(name).getQueueUrl());
+			    }
+			} else {
+			    // get URLs for all queues visible to this account
+			    ListQueuesResult queues = sqs.listQueues();
+			    queueUrls = queues.getQueueUrls();
+			}
+
+			for (String qUrl : queueUrls) {
 				String[] tokens = qUrl.split("\\/");
 				String queueName = tokens[tokens.length - 1];
 


### PR DESCRIPTION
Instead of checking all SQS queues visible to the AWS account, I prefer to give the exporter a list of specific queues to watch.

This patch adds an environment variable `SQS_QUEUE_NAMES` that allows you to specify a comma-delimited list of SQS queue names. If no value is set, it falls back to the current behavior of watching all queues.