### PR TITLE
Ability to specify queue URLs directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,12 @@ AWS credentials can be provided via the following:
 * Instance profile credentials delivered through the Amazon EC2 metadata service if running within AWS
 * IAM role applied to either an Amazon Elastic Container Service (ECS) service or task
 
-By default, the exporter will watch all SQS queues visible to the AWS account. To watch a specific set of queues, supply a comma-separated list of queue names in the environment variable SQS_QUEUE_NAMES or a single queue prefix in SQS_QUEUE_NAME_PREFIX. (SQS_QUEUE_NAMES takes precedence over SQS_QUEUE_NAME_PREFIX) (With no parametera specified via environment variables, the full list of queues will be returned)
+By default, the exporter will watch all SQS queues visible to the AWS account. To watch a specific set of queues, supply one of these parameters:
+* a comma-separated list of queue names in the environment variable `SQS_QUEUE_NAMES`;
+* a single queue prefix in `SQS_QUEUE_NAME_PREFIX`. (SQS_QUEUE_NAMES takes precedence over SQS_QUEUE_NAME_PREFIX);
+* a comma-separated list of queue URLs in `SQS_QUEUE_URLS`.
+
+With no parameters specified via environment variables, the full list of queues will be returned.
 
 ## Docker
 

--- a/src/main/java/org/jmal98/metrics/collector/Sqs.java
+++ b/src/main/java/org/jmal98/metrics/collector/Sqs.java
@@ -47,9 +47,16 @@ public class Sqs extends Collector {
 			List<String> queueUrls;
 
 			// check for manually-specified queue name filters
+			String queueUrlsFromEnv = System.getenv("SQS_QUEUE_URLS");
 			String queueNames = System.getenv("SQS_QUEUE_NAMES");
 			String queueNamePrefix = System.getenv("SQS_QUEUE_NAME_PREFIX");
-			if (queueNames != null) {
+			if (queueUrlsFromEnv != null) {
+				String[] urls = queueUrlsFromEnv.split(",");
+				queueUrls = new ArrayList<String>();
+				for(String url : urls) {
+					queueUrls.add(url);
+				}
+			} else if (queueNames != null) {
 			    // find the URLs for the named queues
 			    String[] names = queueNames.split(",");
 			    queueUrls = new ArrayList<String>();


### PR DESCRIPTION
I needed this as my environment had some stringent restrictions on the IAM role that can access the queues: it only allows `sqs:GetQueueAttributes` on very specific queues (so no `sqs:ListQueues` nor `sqs:GetQueueUrl`).

Also has the added benefit of reducing the metric collection to a single call to SQS instead of 2 (because it doesn't have to retrieve the queues or look up their URLs).

Perhaps, this might be useful to others.