### PR TITLE
Fix support for EKS IAM for SA

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -197,7 +197,27 @@
 
 		<dependency>
 			<groupId>com.amazonaws</groupId>
+			<artifactId>aws-java-sdk-core</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>commons-logging</groupId>
+					<artifactId>commons-logging</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>com.amazonaws</groupId>
 			<artifactId>aws-java-sdk-sqs</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>commons-logging</groupId>
+					<artifactId>commons-logging</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>com.amazonaws</groupId>
+			<artifactId>aws-java-sdk-sts</artifactId>
 			<exclusions>
 				<exclusion>
 					<groupId>commons-logging</groupId>


### PR DESCRIPTION
We have been attempting to no longer use Kube2iam, and opted to use EKS IAM for Sa to provide AWS credentials to our microservices we run in EKS.  The pom file needed to explicitly add missing dependent jar files to the classpath.

- The `DefaultAWSCredentialsProviderChain` was updated in AWS SDK for Java 1.11.620 to support assuming an IAM Role with Web Identity, adding the `WebIdentityTokenCredentialsProvider` to the provider chain.  
- The `WebIdentityTokenCredentialsProvider` uses the AWS STS service